### PR TITLE
#13 fix window configuration.

### DIFF
--- a/lib/smalruby.rb
+++ b/lib/smalruby.rb
@@ -99,7 +99,7 @@ module Smalruby
         attach_thread_input =
           Win32API.new('user32', 'AttachThreadInput', %w(i i i), 'v')
         attach_thread_input.call(this_thread_id, active_thread_id, 1)
-        Win32API.new('user32', 'SetForegroundWindow', %w(i), 'i')
+        Win32API.new('user32', 'BringWindowToTop', %w(i), 'i')
           .call(Window.hWnd)
         attach_thread_input.call(this_thread_id, active_thread_id, 0)
 


### PR DESCRIPTION
下記ページによるとWindowsVista以降ではSetForegroundWindowが正しく動作しない場合があるので
BringWindowToTopを使うことがよいそうです。
参考ページ
https://msdn.microsoft.com/en-us/library/windows/desktop/ms633539%28v=vs.85%29.aspx