### PR TITLE
fix rubocop offense.

### DIFF
--- a/lib/smalruby/version.rb
+++ b/lib/smalruby/version.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
 module Smalruby
-  VERSION =  '0.1.11'
+  VERSION = '0.1.11'
 end


### PR DESCRIPTION
RuboCopによる次の警告に関する修正です．

```
lib/smalruby/version.rb:4:12: C: Unnecessary spacing detected.
  VERSION =  '0.1.11'
           ^
```