### PR TITLE
fix scale_x bug.

### DIFF
--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -207,17 +207,17 @@ module Smalruby
       @vector[:y] = Math.sin(radian)
 
       if @rotation_style == :free
-        self.scale_x = 1
+        self.scale_x = scale_x.abs
         super(val)
       elsif @rotation_style == :left_right
         if @vector[:x] >= 0
-          self.scale_x = 1
+          self.scale_x = scale_x.abs
         else
-          self.scale_x = -1
+          self.scale_x = scale_x.abs * -1
         end
         super(0)
       else
-        self.scale_x = 1
+        self.scale_x = scale_x.abs
         super(0)
       end
     end


### PR DESCRIPTION
下記の様に scale_x を変更している場合に、Character#angle= が実行されると scale_x の絶対値が1に戻ってしまうのを修正しました。

``` ruby
require "smalruby"

cat1 = Character.new(costume: "costume1:cat1.png", x: 200, y: 200, angle: 30)
cat1.scale_x = 2.0
cat1.scale_y = 2.0

cat1.on(:start) do
  loop do
    say(message: scale_x)
    move(10)
    turn_if_reach_wall
  end
end
```
