### PR TITLE
Add stop_all_sounds method.

### DIFF
--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -372,6 +372,14 @@ module Smalruby
       sound.play
     end
 
+    def stop_all_sounds
+      self.class.sound_cache.synchronize do
+        self.class.sound_cache.each do |_, sound|
+          sound.stop
+        end
+      end
+    end
+
     # @!endgroup
 
     # @!group ペン

--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -374,7 +374,7 @@ module Smalruby
 
     def stop_all_sounds
       self.class.sound_cache.synchronize do
-        self.class.sound_cache.each do |_, sound|
+        self.class.sound_cache.each_value do |sound|
           sound.stop
         end
       end


### PR DESCRIPTION
`#stop_all_sounds` メソッドを追加しました。

`each` メソッドを回して `stop` を全部に対して呼んでいます。
Ruby/SDLには `SDL::Mixer.halt(-1)` で全部止める方法がありましたが、DXRubyにはないクラスなので、今の `stop` を呼ぶのになりました。

https://github.com/ohai/rubysdl/blob/master/doc/mixer.rsd#L578
```
halt(channel)

DESC
$[channel] で指定したチャンネルの再生を止めます。-1を与えた場合は
すべてのチャンネルの再生を止めます。
```

タイミング的には少し鳴り始めてから呼び出さないと、うまく止まらない時があるようです。
キーボードのキーを押すと音を鳴るようにしたプログラムで、直ぐに別キーで止めるようにしたので連打すると鳴り止まないことがありました。
ただ、そこらへんは実装時のタイミングということで良いかと思い、PRにしました。