### PR TITLE
Add distance_to_mouse_pointer, distance_to_character method in null_sound branch.

### DIFF
--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -3,6 +3,14 @@ require 'forwardable'
 require 'mutex_m'
 
 module Smalruby
+  class NullSound
+    def initialize(_)
+    end
+
+    def method_missing(symbol, args)
+    end
+  end
+
   # キャラクターを表現するクラス
   class Character < Sprite
     extend Forwardable
@@ -625,7 +633,11 @@ module Smalruby
 
     def new_sound(name)
       self.class.sound_cache.synchronize do
-        self.class.sound_cache[name] ||= Sound.new(asset_path(name))
+        begin
+          self.class.sound_cache[name] ||= Sound.new(asset_path(name))
+        rescue
+          self.class.sound_cache[name] ||= NullSound.new(asset_path(name))
+        end
       end
       self.class.sound_cache[name]
     end

--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -679,5 +679,12 @@ module Smalruby
     def calc_volume
       (255 * @volume / 100.0).to_i
     end
+
+    def distance_to_character(target)
+      tx = target.x
+      ty = target.y
+      distance = Math.sqrt((tx-self.x)**2 + (ty-self.y)**2)
+      return distance.round(6)
+    end
   end
 end

--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -692,14 +692,14 @@ module Smalruby
       mx = Input.mouse_pos_x
       my = Input.mouse_pos_y
       distance = Math.sqrt((mx-self.x)**2 + (my-self.y)**2)
-      return distance.round(6)
+      distance.round(6)
     end
 
     def distance_to_character(target)
       tx = target.x
       ty = target.y
       distance = Math.sqrt((tx-self.x)**2 + (ty-self.y)**2)
-      return distance.round(6)
+      distance.round(6)
     end
   end
 end

--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -679,5 +679,12 @@ module Smalruby
     def calc_volume
       (255 * @volume / 100.0).to_i
     end
+
+    def distance_to_mouse_pointer
+      mx = Input.mouse_pos_x
+      my = Input.mouse_pos_y
+      distance = Math.sqrt((mx-self.x)**2 + (my-self.y)**2)
+      return distance.round(6)
+    end
   end
 end


### PR DESCRIPTION
`null_sound` ブランチで `Character#distance_to_mouse_pointer` と `Character#distance_to_character` メソッドを追加しました．

距離の計算にはスプライトと対象の座標から三平方の定理を用いています．
現状，スプライトの座標は左上が[0, 0]となっているため，状況によっては算出された距離と見た目が合わない可能性がありますが，スプライトの左上を中心とすると正確な位置が計算されます．

スプライトとマウスポインタとの距離には `distance_to_mouse_pointer` を使います．Scratchに合わせて小数点以下6桁までの値を返します．
また，スプライト間の距離には `distance_to_character` を使います．引数として対象のスプライトのインスタンスを指定する必要があります．これも小数点以下6桁までの値を返します．