### PR TITLE
Add play_until_done method.

### DIFF
--- a/lib/smalruby/character.rb
+++ b/lib/smalruby/character.rb
@@ -378,6 +378,23 @@ module Smalruby
       sound.play
     end
 
+    # 終わるまで(  )の音を鳴らす
+    def play_until_done(option = {})
+      raise NotImplementedError unless defined?(DXRubySDL)
+      defaults = {
+        name: 'piano_do.wav'
+      }
+      opt = process_optional_arguments(option, defaults)
+
+      sound = new_sound(opt[:name])
+      sound.loop_count = 0
+      sound.set_volume(calc_volume)
+      sound.play
+      channel = sound.instance_variable_get('@sound')
+                     .instance_variable_get('@last_played_channel')
+      await while channel ? SDL::Mixer.play?(channel) : SDL::Mixer.playMusic?
+    end
+
     def stop_all_sounds
       self.class.sound_cache.synchronize do
         self.class.sound_cache.each_value do |sound|


### PR DESCRIPTION
`play_until_done` メソッドを追加しました。

鳴らした後で待つようにしていますが、それはScratchの「終わるまで（）の音を鳴らす」ブロックの動作の以下を参考にしました。

https://jp.scratch-wiki.info/wiki/%E7%B5%82%E3%82%8F%E3%82%8B%E3%81%BE%E3%81%A7_()_%E3%81%AE%E9%9F%B3%E3%82%92%E9%B3%B4%E3%82%89%E3%81%99_(%E3%83%96%E3%83%AD%E3%83%83%E3%82%AF)

> 終わるまで () の音を鳴らす ブロック（音ブロック／ スタックブロック）は、指定した音声を再生し、再生が終了するまで、スクリプトの実行を停止するブロックである。

口頭にて高尾さんに相談しましたが、DXRubyに再生中なのかを取得するメソッドがなかったので、DXRubySDLが読み込まれていない場合はNotImplementedError例外を発生させるようにしています。
`DXRuby::Sound` に再生中なのかを知るメソッドがありませんが、 `Ayame/Ruby` にはreadme.txtによるとありましたが、このメソッド以外も修正する必要があるので、こちらは使用していません。

https://github.com/mirichi/dxruby-doc/wiki

> Ayame#playing? -> true/false
>  再生中の場合にtrueを返します。
>  一時停止中もtrueになります。

DXRubyのSoundクラスに再生中かを返すメソッドがないのを確認したのは、以下のドキュメントです。
http://mirichi.github.io/dxruby-doc/api/Sound.html

SDLの再生中なのかを取得するのは、以下のメソッドを使用しました。

https://www.kmc.gr.jp/~ohai/rubysdl_doc.html#label-347

> SDL::Mixer.play?(channel)
>       指定したchannelが現在演奏していればtrueを、していなければ falseを返す。
>
> SDL::Mixer.playMusic?
> SDL::Mixer.play_music?
>       音楽が演奏されていればtrue、していなければfalseを返す。
